### PR TITLE
adding comprehensive tests for resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 1099Policy Node.js Library
 
+[![Coverage Status](https://coveralls.io/repos/github/1099policy/ten99policy-node/badge.svg?branch=master)](https://coveralls.io/github/1099policy/ten99policy-node?branch=master)
+
 Node.js client library for 1099Policy platform.
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 1099Policy Node.js Library
 
-[![Coverage Status](https://coveralls.io/repos/github/1099policy/ten99policy-node/badge.svg?branch=master)](https://coveralls.io/github/1099policy/ten99policy-node?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/1099policy/ten99policy-node/badge.svg?branch=structuring-tests)](https://coveralls.io/github/1099policy/ten99policy-node?branch=structuring-tests)
 
 Node.js client library for 1099Policy platform.
 

--- a/lib/ResourceNamespace.js
+++ b/lib/ResourceNamespace.js
@@ -1,17 +1,17 @@
 'use strict';
 
-function ResourceNamespace(stripe, resources) {
+function ResourceNamespace(ten99policy, resources) {
   for (const name in resources) {
     const camelCaseName = name[0].toLowerCase() + name.substring(1);
-    const resource = new resources[name](stripe);
+    const resource = new resources[name](ten99policy);
 
     this[camelCaseName] = resource;
   }
 }
 
 module.exports = function(namespace, resources) {
-  return function(stripe) {
-    return new ResourceNamespace(stripe, resources);
+  return function(ten99policy) {
+    return new ResourceNamespace(ten99policy, resources);
   };
 };
 

--- a/lib/ResourceNamespace.js
+++ b/lib/ResourceNamespace.js
@@ -1,0 +1,18 @@
+'use strict';
+
+function ResourceNamespace(stripe, resources) {
+  for (const name in resources) {
+    const camelCaseName = name[0].toLowerCase() + name.substring(1);
+    const resource = new resources[name](stripe);
+
+    this[camelCaseName] = resource;
+  }
+}
+
+module.exports = function(namespace, resources) {
+  return function(stripe) {
+    return new ResourceNamespace(stripe, resources);
+  };
+};
+
+module.exports.ResourceNamespace = ResourceNamespace;

--- a/lib/Ten99Policy.js
+++ b/lib/Ten99Policy.js
@@ -161,7 +161,7 @@ Ten99Policy.prototype = {
     }
 
     // config can only be an object
-    if (!config === Object(config) && !Array.isArray(config)) {
+    if (typeof config !== 'object' || (!config === Object(config) && !Array.isArray(config))) {
       throw new Error('Config must be an object');
     }
 

--- a/lib/Ten99Policy.js
+++ b/lib/Ten99Policy.js
@@ -161,7 +161,10 @@ Ten99Policy.prototype = {
     }
 
     // config can only be an object
-    if (typeof config !== 'object' || (!config === Object(config) && !Array.isArray(config))) {
+    if (
+      typeof config !== 'object' ||
+      (!config === Object(config) && !Array.isArray(config))
+    ) {
       throw new Error('Config must be an object');
     }
 

--- a/lib/Ten99PolicyResource.js
+++ b/lib/Ten99PolicyResource.js
@@ -203,6 +203,8 @@ Ten99PolicyResource.prototype = {
         try {
           response = JSON.parse(response);
 
+          // console.log(response);
+
           if (response.error) {
             let err;
 

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,14 @@
+module.exports = {
+    "env": {
+        "mocha": true
+    },
+    "plugins": [
+        "chai-friendly"
+    ],
+    "rules": {
+        "no-loop-func": "off",
+        "no-sync": "off",
+        "no-unused-expressions": 0,
+        "chai-friendly/no-unused-expressions": 2
+    }
+};

--- a/test/resources/Contractors.spec.js
+++ b/test/resources/Contractors.spec.js
@@ -1,0 +1,210 @@
+'use strict';
+
+const ten99policy = require('../../testUtils').getSpyableTen99Policy();
+const expect = require('chai').expect;
+
+const TEST_AUTH_KEY = 'aGN0bIwXnHdw5645VABjPdSn8nWY7G11';
+
+describe('Contractors Resource', () => {
+  describe('retrieve', () => {
+    it('Sends the correct request', () => {
+      ten99policy.contractors.retrieve('abcdef');
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/api/v1/contractors/abcdef',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth]', () => {
+      ten99policy.contractors.retrieve('abcdef', TEST_AUTH_KEY);
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/api/v1/contractors/abcdef',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+  });
+
+  describe('create', () => {
+    it('Sends the correct request', () => {
+      ten99policy.contractors.create({description: 'Some contractor'});
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/contractors',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some contractor'},
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth]', () => {
+      ten99policy.contractors.create(
+        {description: 'Some contractor'},
+        TEST_AUTH_KEY
+      );
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/contractors',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some contractor'},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth and no body]', () => {
+      ten99policy.contractors.create(TEST_AUTH_KEY);
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/contractors',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified idempotencyKey in options]', () => {
+      ten99policy.contractors.create(
+        {description: 'Some contractor'},
+        {idempotencyKey: 'foo'}
+      );
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/contractors',
+        headers: {
+          'Idempotency-Key': 'foo',
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some contractor'},
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth in options]', () => {
+      ten99policy.contractors.create(
+        {description: 'Some contractor'},
+        {apiKey: TEST_AUTH_KEY}
+      );
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/contractors',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some contractor'},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth and idempotent key in options]', () => {
+      ten99policy.contractors.create(
+        {description: 'Some contractor'},
+        {apiKey: TEST_AUTH_KEY, idempotencyKey: 'foo'}
+      );
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/contractors',
+        headers: {
+          'Idempotency-Key': 'foo',
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some contractor'},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth in options and no body]', () => {
+      ten99policy.contractors.create({apiKey: TEST_AUTH_KEY});
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/contractors',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    describe('update', () => {
+      it('Sends the correct request', () => {
+        ten99policy.contractors.update('abcdef', {
+          description: 'Foo "baz"',
+        });
+        expect(ten99policy.LAST_REQUEST).to.deep.equal({
+          method: 'PUT',
+          url: '/api/v1/contractors/abcdef',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {description: 'Foo "baz"'},
+          settings: {},
+        });
+      });
+    });
+
+    describe('del', () => {
+      it('Sends the correct request', () => {
+        ten99policy.contractors.del('abcdef');
+        expect(ten99policy.LAST_REQUEST).to.deep.equal({
+          method: 'DELETE',
+          url: '/api/v1/contractors/abcdef',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {},
+          settings: {},
+        });
+      });
+    });
+
+    describe('list', () => {
+      it('Sends the correct request', () => {
+        ten99policy.contractors.list();
+        expect(ten99policy.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/api/v1/contractors',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {},
+          settings: {},
+        });
+      });
+
+      it('Sends the correct request [with specified auth]', () => {
+        ten99policy.contractors.list(TEST_AUTH_KEY);
+        expect(ten99policy.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/api/v1/contractors',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {},
+          auth: TEST_AUTH_KEY,
+          settings: {},
+        });
+      });
+    });
+  });
+});

--- a/test/resources/Entities.spec.js
+++ b/test/resources/Entities.spec.js
@@ -1,0 +1,207 @@
+'use strict';
+
+const ten99policy = require('../../testUtils').getSpyableTen99Policy();
+const expect = require('chai').expect;
+
+const TEST_AUTH_KEY = 'aGN0bIwXnHdw5645VABjPdSn8nWY7G11';
+
+describe('Entities Resource', () => {
+  describe('retrieve', () => {
+    it('Sends the correct request', () => {
+      ten99policy.entities.retrieve('abcdef');
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/api/v1/entities/abcdef',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth]', () => {
+      ten99policy.entities.retrieve('abcdef', TEST_AUTH_KEY);
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/api/v1/entities/abcdef',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+  });
+
+  describe('create', () => {
+    it('Sends the correct request', () => {
+      ten99policy.entities.create({description: 'Some entity'});
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/entities',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some entity'},
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth]', () => {
+      ten99policy.entities.create({description: 'Some entity'}, TEST_AUTH_KEY);
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/entities',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some entity'},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth and no body]', () => {
+      ten99policy.entities.create(TEST_AUTH_KEY);
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/entities',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified idempotencyKey in options]', () => {
+      ten99policy.entities.create(
+        {description: 'Some entity'},
+        {idempotencyKey: 'foo'}
+      );
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/entities',
+        headers: {
+          'Idempotency-Key': 'foo',
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some entity'},
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth in options]', () => {
+      ten99policy.entities.create(
+        {description: 'Some entity'},
+        {apiKey: TEST_AUTH_KEY}
+      );
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/entities',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some entity'},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth and idempotent key in options]', () => {
+      ten99policy.entities.create(
+        {description: 'Some entity'},
+        {apiKey: TEST_AUTH_KEY, idempotencyKey: 'foo'}
+      );
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/entities',
+        headers: {
+          'Idempotency-Key': 'foo',
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some entity'},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth in options and no body]', () => {
+      ten99policy.entities.create({apiKey: TEST_AUTH_KEY});
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/entities',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    describe('update', () => {
+      it('Sends the correct request', () => {
+        ten99policy.entities.update('abcdef', {
+          description: 'Foo "baz"',
+        });
+        expect(ten99policy.LAST_REQUEST).to.deep.equal({
+          method: 'PUT',
+          url: '/api/v1/entities/abcdef',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {description: 'Foo "baz"'},
+          settings: {},
+        });
+      });
+    });
+
+    describe('del', () => {
+      it('Sends the correct request', () => {
+        ten99policy.entities.del('abcdef');
+        expect(ten99policy.LAST_REQUEST).to.deep.equal({
+          method: 'DELETE',
+          url: '/api/v1/entities/abcdef',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {},
+          settings: {},
+        });
+      });
+    });
+
+    describe('list', () => {
+      it('Sends the correct request', () => {
+        ten99policy.entities.list();
+        expect(ten99policy.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/api/v1/entities',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {},
+          settings: {},
+        });
+      });
+
+      it('Sends the correct request [with specified auth]', () => {
+        ten99policy.entities.list(TEST_AUTH_KEY);
+        expect(ten99policy.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/api/v1/entities',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {},
+          auth: TEST_AUTH_KEY,
+          settings: {},
+        });
+      });
+    });
+  });
+});

--- a/test/resources/Jobs.spec.js
+++ b/test/resources/Jobs.spec.js
@@ -1,0 +1,207 @@
+'use strict';
+
+const ten99policy = require('../../testUtils').getSpyableTen99Policy();
+const expect = require('chai').expect;
+
+const TEST_AUTH_KEY = 'aGN0bIwXnHdw5645VABjPdSn8nWY7G11';
+
+describe('Jobs Resource', () => {
+  describe('retrieve', () => {
+    it('Sends the correct request', () => {
+      ten99policy.jobs.retrieve('abcdef');
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/api/v1/jobs/abcdef',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth]', () => {
+      ten99policy.jobs.retrieve('abcdef', TEST_AUTH_KEY);
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/api/v1/jobs/abcdef',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+  });
+
+  describe('create', () => {
+    it('Sends the correct request', () => {
+      ten99policy.jobs.create({description: 'Some job'});
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/jobs',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some job'},
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth]', () => {
+      ten99policy.jobs.create({description: 'Some job'}, TEST_AUTH_KEY);
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/jobs',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some job'},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth and no body]', () => {
+      ten99policy.jobs.create(TEST_AUTH_KEY);
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/jobs',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified idempotencyKey in options]', () => {
+      ten99policy.jobs.create(
+        {description: 'Some job'},
+        {idempotencyKey: 'foo'}
+      );
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/jobs',
+        headers: {
+          'Idempotency-Key': 'foo',
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some job'},
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth in options]', () => {
+      ten99policy.jobs.create(
+        {description: 'Some job'},
+        {apiKey: TEST_AUTH_KEY}
+      );
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/jobs',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some job'},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth and idempotent key in options]', () => {
+      ten99policy.jobs.create(
+        {description: 'Some job'},
+        {apiKey: TEST_AUTH_KEY, idempotencyKey: 'foo'}
+      );
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/jobs',
+        headers: {
+          'Idempotency-Key': 'foo',
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some job'},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth in options and no body]', () => {
+      ten99policy.jobs.create({apiKey: TEST_AUTH_KEY});
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/jobs',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    describe('update', () => {
+      it('Sends the correct request', () => {
+        ten99policy.jobs.update('abcdef', {
+          description: 'Foo "baz"',
+        });
+        expect(ten99policy.LAST_REQUEST).to.deep.equal({
+          method: 'PUT',
+          url: '/api/v1/jobs/abcdef',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {description: 'Foo "baz"'},
+          settings: {},
+        });
+      });
+    });
+
+    describe('del', () => {
+      it('Sends the correct request', () => {
+        ten99policy.jobs.del('abcdef');
+        expect(ten99policy.LAST_REQUEST).to.deep.equal({
+          method: 'DELETE',
+          url: '/api/v1/jobs/abcdef',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {},
+          settings: {},
+        });
+      });
+    });
+
+    describe('list', () => {
+      it('Sends the correct request', () => {
+        ten99policy.jobs.list();
+        expect(ten99policy.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/api/v1/jobs',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {},
+          settings: {},
+        });
+      });
+
+      it('Sends the correct request [with specified auth]', () => {
+        ten99policy.jobs.list(TEST_AUTH_KEY);
+        expect(ten99policy.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/api/v1/jobs',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {},
+          auth: TEST_AUTH_KEY,
+          settings: {},
+        });
+      });
+    });
+  });
+});

--- a/test/resources/Policies.spec.js
+++ b/test/resources/Policies.spec.js
@@ -1,0 +1,207 @@
+'use strict';
+
+const ten99policy = require('../../testUtils').getSpyableTen99Policy();
+const expect = require('chai').expect;
+
+const TEST_AUTH_KEY = 'aGN0bIwXnHdw5645VABjPdSn8nWY7G11';
+
+describe('Policy Resource', () => {
+  describe('retrieve', () => {
+    it('Sends the correct request', () => {
+      ten99policy.policies.retrieve('abcdef');
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/api/v1/policies/abcdef',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth]', () => {
+      ten99policy.policies.retrieve('abcdef', TEST_AUTH_KEY);
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/api/v1/policies/abcdef',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+  });
+
+  describe('create', () => {
+    it('Sends the correct request', () => {
+      ten99policy.policies.create({description: 'Some policy'});
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/policies',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some policy'},
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth]', () => {
+      ten99policy.policies.create({description: 'Some policy'}, TEST_AUTH_KEY);
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/policies',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some policy'},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth and no body]', () => {
+      ten99policy.policies.create(TEST_AUTH_KEY);
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/policies',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified idempotencyKey in options]', () => {
+      ten99policy.policies.create(
+        {description: 'Some policy'},
+        {idempotencyKey: 'foo'}
+      );
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/policies',
+        headers: {
+          'Idempotency-Key': 'foo',
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some policy'},
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth in options]', () => {
+      ten99policy.policies.create(
+        {description: 'Some policy'},
+        {apiKey: TEST_AUTH_KEY}
+      );
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/policies',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some policy'},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth and idempotent key in options]', () => {
+      ten99policy.policies.create(
+        {description: 'Some policy'},
+        {apiKey: TEST_AUTH_KEY, idempotencyKey: 'foo'}
+      );
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/policies',
+        headers: {
+          'Idempotency-Key': 'foo',
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some policy'},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth in options and no body]', () => {
+      ten99policy.policies.create({apiKey: TEST_AUTH_KEY});
+      expect(ten99policy.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/policies',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    describe('update', () => {
+      it('Sends the correct request', () => {
+        ten99policy.policies.update('abcdef', {
+          description: 'Foo "baz"',
+        });
+        expect(ten99policy.LAST_REQUEST).to.deep.equal({
+          method: 'PUT',
+          url: '/api/v1/policies/abcdef',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {description: 'Foo "baz"'},
+          settings: {},
+        });
+      });
+    });
+
+    describe('del', () => {
+      it('Sends the correct request', () => {
+        ten99policy.policies.del('abcdef');
+        expect(ten99policy.LAST_REQUEST).to.deep.equal({
+          method: 'DELETE',
+          url: '/api/v1/policies/abcdef',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {},
+          settings: {},
+        });
+      });
+    });
+
+    describe('list', () => {
+      it('Sends the correct request', () => {
+        ten99policy.policies.list();
+        expect(ten99policy.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/api/v1/policies',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {},
+          settings: {},
+        });
+      });
+
+      it('Sends the correct request [with specified auth]', () => {
+        ten99policy.policies.list(TEST_AUTH_KEY);
+        expect(ten99policy.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/api/v1/policies',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {},
+          auth: TEST_AUTH_KEY,
+          settings: {},
+        });
+      });
+    });
+  });
+});

--- a/test/resources/Quotes.spec.js
+++ b/test/resources/Quotes.spec.js
@@ -1,0 +1,207 @@
+'use strict';
+
+const ten99quote = require('../../testUtils').getSpyableTen99Policy();
+const expect = require('chai').expect;
+
+const TEST_AUTH_KEY = 'aGN0bIwXnHdw5645VABjPdSn8nWY7G11';
+
+describe('Quote Resource', () => {
+  describe('retrieve', () => {
+    it('Sends the correct request', () => {
+      ten99quote.quotes.retrieve('abcdef');
+      expect(ten99quote.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/api/v1/quotes/abcdef',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth]', () => {
+      ten99quote.quotes.retrieve('abcdef', TEST_AUTH_KEY);
+      expect(ten99quote.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/api/v1/quotes/abcdef',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+  });
+
+  describe('create', () => {
+    it('Sends the correct request', () => {
+      ten99quote.quotes.create({description: 'Some quote'});
+      expect(ten99quote.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/quotes',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some quote'},
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth]', () => {
+      ten99quote.quotes.create({description: 'Some quote'}, TEST_AUTH_KEY);
+      expect(ten99quote.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/quotes',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some quote'},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth and no body]', () => {
+      ten99quote.quotes.create(TEST_AUTH_KEY);
+      expect(ten99quote.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/quotes',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified idempotencyKey in options]', () => {
+      ten99quote.quotes.create(
+        {description: 'Some quote'},
+        {idempotencyKey: 'foo'}
+      );
+      expect(ten99quote.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/quotes',
+        headers: {
+          'Idempotency-Key': 'foo',
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some quote'},
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth in options]', () => {
+      ten99quote.quotes.create(
+        {description: 'Some quote'},
+        {apiKey: TEST_AUTH_KEY}
+      );
+      expect(ten99quote.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/quotes',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some quote'},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth and idempotent key in options]', () => {
+      ten99quote.quotes.create(
+        {description: 'Some quote'},
+        {apiKey: TEST_AUTH_KEY, idempotencyKey: 'foo'}
+      );
+      expect(ten99quote.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/quotes',
+        headers: {
+          'Idempotency-Key': 'foo',
+          'Content-Type': 'application/json',
+        },
+        data: {description: 'Some quote'},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    it('Sends the correct request [with specified auth in options and no body]', () => {
+      ten99quote.quotes.create({apiKey: TEST_AUTH_KEY});
+      expect(ten99quote.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/api/v1/quotes',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        data: {},
+        auth: TEST_AUTH_KEY,
+        settings: {},
+      });
+    });
+
+    describe('update', () => {
+      it('Sends the correct request', () => {
+        ten99quote.quotes.update('abcdef', {
+          description: 'Foo "baz"',
+        });
+        expect(ten99quote.LAST_REQUEST).to.deep.equal({
+          method: 'PUT',
+          url: '/api/v1/quotes/abcdef',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {description: 'Foo "baz"'},
+          settings: {},
+        });
+      });
+    });
+
+    describe('del', () => {
+      it('Sends the correct request', () => {
+        ten99quote.quotes.del('abcdef');
+        expect(ten99quote.LAST_REQUEST).to.deep.equal({
+          method: 'DELETE',
+          url: '/api/v1/quotes/abcdef',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {},
+          settings: {},
+        });
+      });
+    });
+
+    describe('list', () => {
+      it('Sends the correct request', () => {
+        ten99quote.quotes.list();
+        expect(ten99quote.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/api/v1/quotes',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {},
+          settings: {},
+        });
+      });
+
+      it('Sends the correct request [with specified auth]', () => {
+        ten99quote.quotes.list(TEST_AUTH_KEY);
+        expect(ten99quote.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/api/v1/quotes',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          data: {},
+          auth: TEST_AUTH_KEY,
+          settings: {},
+        });
+      });
+    });
+  });
+});

--- a/test/ten99policy.spec.js
+++ b/test/ten99policy.spec.js
@@ -5,27 +5,164 @@
 const testUtils = require('../testUtils');
 const Ten99Policy = require('../lib/ten99policy');
 const expect = require('chai').expect;
+const cleanup = new testUtils.CleanupUtility();
+
+const ten99policy = new Ten99Policy({
+  key: 't9sk_test_29374df8-4462-4900-ad3a-145aa46fbfca',
+  host: 'localhost',
+  port: '5000',
+  protocol: 'http',
+});
+
+const contractorData = {
+  company_name: 'John & Friends',
+  first_name: 'John',
+  last_name: 'Doe',
+  email: `example-${Math.random().toString(36).substring(7)}@gmail.com`,
+  phone: '415-111-1111',
+  address: {
+    line1: '2211 Mission St',
+    line2: '',
+    locality: 'San Francisco,',
+    region: 'CA',
+    postalcode: '94110',
+  },
+};
 
 describe('Ten99Policy Module', function() {
+  this.timeout(20000);
+
   describe('config object', () => {
     it('should only accept an object', () => {
-      // expect(() => {
-      //   Ten99Policy(123456);
-      // }).to.throw(/Config must be an object/);
+      expect(() => {
+        Ten99Policy(123456);
+      }).to.throw(/Config must be an object/);
 
       expect(() => {
         Ten99Policy({
           incorrectKey: true,
         });
       }).to.throw(
-        /Config object may only contain the following: key, apiVersion, maxNetworkRetries, timeout, host, port, protocol/
+        /Config object may only contain the following:/
       );
 
       expect(() => {
         Ten99Policy({
           key: testUtils.getUserTen99PolicyKey(),
+          maxNetworkRetries: 2,
+          timeout: 123,
+          host: 'foo.ten99policy.com',
         });
       }).to.not.throw();
+    });
+
+    it('should forbid sending http to *.ten99policy.com', () => {
+      expect(() => {
+        Ten99Policy({
+          key: testUtils.getUserTen99PolicyKey(),
+          host: 'foo.ten99policy.com',
+          protocol: 'http',
+        });
+      }).to.throw(/The `https` protocol must be used/);
+
+      expect(() => {
+        Ten99Policy({
+          key: testUtils.getUserTen99PolicyKey(),
+          protocol: 'http',
+        });
+      }).to.throw(/The `https` protocol must be used/);
+
+      expect(() => {
+        Ten99Policy({
+          key: testUtils.getUserTen99PolicyKey(),
+          protocol: 'http',
+          host: 'api.ten99policy.com',
+        });
+      }).to.throw(/The `https` protocol must be used/);
+
+      expect(() => {
+        Ten99Policy({
+          key: testUtils.getUserTen99PolicyKey(),
+          protocol: 'https',
+          host: 'api.ten99policy.com',
+        });
+      }).not.to.throw();
+
+      expect(() => {
+        Ten99Policy({
+          key: testUtils.getUserTen99PolicyKey(),
+          host: 'api.ten99policy.com',
+        });
+      }).not.to.throw();
+
+      expect(() => {
+        Ten99Policy({
+          key: testUtils.getUserTen99PolicyKey(),
+          protocol: 'http',
+          host: 'localhost',
+        });
+      }).not.to.throw();
+    });
+
+    describe('setApiKey', () => {
+      it('uses Bearer auth', () => {
+        expect(ten99policy.getApiField('auth')).to.equal(
+          `Bearer ${testUtils.getUserTen99PolicyKey()}`
+        );
+      });
+    });
+
+    describe('Callback support', () => {
+      describe('Any given endpoint', () => {
+        it('Will call a callback if successful', () =>
+          expect(
+            new Promise((resolve, reject) => {
+              // this is just to ensure our api creates a new record
+              contractorData.email = `example-${Math.random().toString(36).substring(7)}@gmail.com`;
+
+              ten99policy.contractors.create(contractorData, (err, contractor) => {
+                cleanup.deleteContractor(contractor.id);
+                resolve('Called!');
+              });
+            })
+          ).to.eventually.equal('Called!'));
+
+        describe('lastResponse', () => {
+          it('Will expose HTTP response object', () =>
+            expect(
+              new Promise((resolve, reject) => {
+                // this is just to ensure our api creates a new record
+                contractorData.email = `example-${Math.random().toString(36).substring(7)}@gmail.com`;
+
+                ten99policy.contractors.create(contractorData, (err, contractor) => {
+                  cleanup.deleteContractor(contractor.id);
+
+                  const headers = contractor.lastResponse.headers;
+                  expect(headers).to.contain.keys('server');
+
+                  resolve('Called!');
+                });
+              })
+            ).to.eventually.equal('Called!'));
+        });
+
+        it('Given an error the callback will receive it', () =>
+          expect(
+            new Promise((resolve, reject) => {
+              ten99policy.contractors.update(
+                'nonExistentContractorId',
+                {wrongContractor: {}},
+                (err, contract) => {
+                  if (err) {
+                    resolve('ErrorWasPassed');
+                  } else {
+                    reject(new Error('NoErrorPassed'));
+                  }
+                }
+              );
+            })
+          ).to.eventually.become('ErrorWasPassed'));
+      });
     });
   });
 });

--- a/test/ten99policy.spec.js
+++ b/test/ten99policy.spec.js
@@ -18,7 +18,9 @@ const contractorData = {
   company_name: 'John & Friends',
   first_name: 'John',
   last_name: 'Doe',
-  email: `example-${Math.random().toString(36).substring(7)}@gmail.com`,
+  email: `example-${Math.random()
+    .toString(36)
+    .substring(7)}@gmail.com`,
   phone: '415-111-1111',
   address: {
     line1: '2211 Mission St',
@@ -42,9 +44,7 @@ describe('Ten99Policy Module', function() {
         Ten99Policy({
           incorrectKey: true,
         });
-      }).to.throw(
-        /Config object may only contain the following:/
-      );
+      }).to.throw(/Config object may only contain the following:/);
 
       expect(() => {
         Ten99Policy({
@@ -118,12 +118,17 @@ describe('Ten99Policy Module', function() {
           expect(
             new Promise((resolve, reject) => {
               // this is just to ensure our api creates a new record
-              contractorData.email = `example-${Math.random().toString(36).substring(7)}@gmail.com`;
+              contractorData.email = `example-${Math.random()
+                .toString(36)
+                .substring(7)}@gmail.com`;
 
-              ten99policy.contractors.create(contractorData, (err, contractor) => {
-                cleanup.deleteContractor(contractor.id);
-                resolve('Called!');
-              });
+              ten99policy.contractors.create(
+                contractorData,
+                (err, contractor) => {
+                  cleanup.deleteContractor(contractor.id);
+                  resolve('Called!');
+                }
+              );
             })
           ).to.eventually.equal('Called!'));
 
@@ -132,16 +137,21 @@ describe('Ten99Policy Module', function() {
             expect(
               new Promise((resolve, reject) => {
                 // this is just to ensure our api creates a new record
-                contractorData.email = `example-${Math.random().toString(36).substring(7)}@gmail.com`;
+                contractorData.email = `example-${Math.random()
+                  .toString(36)
+                  .substring(7)}@gmail.com`;
 
-                ten99policy.contractors.create(contractorData, (err, contractor) => {
-                  cleanup.deleteContractor(contractor.id);
+                ten99policy.contractors.create(
+                  contractorData,
+                  (err, contractor) => {
+                    cleanup.deleteContractor(contractor.id);
 
-                  const headers = contractor.lastResponse.headers;
-                  expect(headers).to.contain.keys('server');
+                    const headers = contractor.lastResponse.headers;
+                    expect(headers).to.contain.keys('server');
 
-                  resolve('Called!');
-                });
+                    resolve('Called!');
+                  }
+                );
               })
             ).to.eventually.equal('Called!'));
         });

--- a/testUtils/index.js
+++ b/testUtils/index.js
@@ -3,7 +3,7 @@
 require('mocha');
 require('chai').use(require('chai-as-promised'));
 
-module.exports = {
+const utils = (module.exports = {
   getUserTen99PolicyKey: () => {
     const key =
       process.env.TEN99POLICY_TEST_API_KEY ||
@@ -11,4 +11,76 @@ module.exports = {
 
     return key;
   },
-};
+
+   /**
+   * A utility where cleanup functions can be registered to be called post-spec.
+   * CleanupUtility will automatically register on the mocha afterEach hook,
+   * ensuring its called after each descendent-describe block.
+   */
+  CleanupUtility: (() => {
+    CleanupUtility.DEFAULT_TIMEOUT = 20000;
+
+    function CleanupUtility(timeout) {
+      const self = this;
+
+      this._cleanupFns = [];
+      this._ten99policy = require('../lib/ten99policy')({
+        key: utils.getUserTen99PolicyKey(),
+        host: 'localhost',
+        port: '5000',
+        protocol: 'http',
+      });
+
+      afterEach(function(done) {
+        this.timeout(timeout || CleanupUtility.DEFAULT_TIMEOUT);
+        return self.doCleanup(done);
+      });
+    }
+
+    CleanupUtility.prototype = {
+      doCleanup(done) {
+        const cleanups = this._cleanupFns;
+        const total = cleanups.length;
+
+        let completed = 0;
+        let fn;
+
+        while ((fn = cleanups.shift())) {
+          const promise = fn.call(this);
+          if (!promise || !promise.then) {
+            throw new Error(
+              'CleanupUtility expects cleanup functions to return promises!'
+            );
+          }
+          promise.then(
+            () => {
+              // cleanup successful
+              completed += 1;
+              if (completed === total) {
+                done();
+              }
+            },
+            (err) => {
+              // not successful
+              throw err;
+            }
+          );
+        }
+        if (total === 0) {
+          done();
+        }
+      },
+      add(fn) {
+        this._cleanupFns.push(fn);
+      },
+      deleteContractor(contractorId) {
+        this.add(function() {
+          return this._ten99policy.contractors.del(contractorId);
+        });
+      },
+    };
+
+    return CleanupUtility;
+  })(),
+
+});


### PR DESCRIPTION
```
Contractors Resource
    retrieve
      ✓ Sends the correct request
      ✓ Sends the correct request [with specified auth]
    create
      ✓ Sends the correct request
      ✓ Sends the correct request [with specified auth]
      ✓ Sends the correct request [with specified auth and no body]
      ✓ Sends the correct request [with specified idempotencyKey in options]
      ✓ Sends the correct request [with specified auth in options]
      ✓ Sends the correct request [with specified auth and idempotent key in options]
      ✓ Sends the correct request [with specified auth in options and no body]
      update
        ✓ Sends the correct request
      del
        ✓ Sends the correct request
      list
        ✓ Sends the correct request
        ✓ Sends the correct request [with specified auth]

  Entities Resource
    retrieve
      ✓ Sends the correct request
      ✓ Sends the correct request [with specified auth]
    create
      ✓ Sends the correct request
      ✓ Sends the correct request [with specified auth]
      ✓ Sends the correct request [with specified auth and no body]
      ✓ Sends the correct request [with specified idempotencyKey in options]
      ✓ Sends the correct request [with specified auth in options]
      ✓ Sends the correct request [with specified auth and idempotent key in options]
      ✓ Sends the correct request [with specified auth in options and no body]
      update
        ✓ Sends the correct request
      del
        ✓ Sends the correct request
      list
        ✓ Sends the correct request
        ✓ Sends the correct request [with specified auth]

  Jobs Resource
    retrieve
      ✓ Sends the correct request
      ✓ Sends the correct request [with specified auth]
    create
      ✓ Sends the correct request
      ✓ Sends the correct request [with specified auth]
      ✓ Sends the correct request [with specified auth and no body]
      ✓ Sends the correct request [with specified idempotencyKey in options]
      ✓ Sends the correct request [with specified auth in options]
      ✓ Sends the correct request [with specified auth and idempotent key in options]
      ✓ Sends the correct request [with specified auth in options and no body]
      update
        ✓ Sends the correct request
      del
        ✓ Sends the correct request
      list
        ✓ Sends the correct request
        ✓ Sends the correct request [with specified auth]

  Policy Resource
    retrieve
      ✓ Sends the correct request
      ✓ Sends the correct request [with specified auth]
    create
      ✓ Sends the correct request
      ✓ Sends the correct request [with specified auth]
      ✓ Sends the correct request [with specified auth and no body]
      ✓ Sends the correct request [with specified idempotencyKey in options]
      ✓ Sends the correct request [with specified auth in options]
      ✓ Sends the correct request [with specified auth and idempotent key in options]
      ✓ Sends the correct request [with specified auth in options and no body]
      update
        ✓ Sends the correct request
      del
        ✓ Sends the correct request
      list
        ✓ Sends the correct request
        ✓ Sends the correct request [with specified auth]

  Quote Resource
    retrieve
      ✓ Sends the correct request
      ✓ Sends the correct request [with specified auth]
    create
      ✓ Sends the correct request
      ✓ Sends the correct request [with specified auth]
      ✓ Sends the correct request [with specified auth and no body]
      ✓ Sends the correct request [with specified idempotencyKey in options]
      ✓ Sends the correct request [with specified auth in options]
      ✓ Sends the correct request [with specified auth and idempotent key in options]
      ✓ Sends the correct request [with specified auth in options and no body]
      update
        ✓ Sends the correct request
      del
        ✓ Sends the correct request
      list
        ✓ Sends the correct request
        ✓ Sends the correct request [with specified auth]

  Ten99Policy Module
    config object
      ✓ should only accept an object
      ✓ should forbid sending http to *.ten99policy.com
      setApiKey
        ✓ uses Bearer auth
      Callback support
        Any given endpoint
          ✓ Will call a callback if successful (60ms)
          ✓ Given an error the callback will receive it
          lastResponse
            ✓ Will expose HTTP response object


  71 passing (232ms)

-------------------------|----------|----------|----------|----------|-------------------|
File                     |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-------------------------|----------|----------|----------|----------|-------------------|
All files                |    76.18 |     56.2 |    80.91 |    76.35 |                   |
 lib                     |    74.11 |    54.44 |    78.95 |    74.28 |                   |
  Error.js               |    76.67 |    11.11 |      100 |    76.67 |... 33,35,37,39,41 |
  ResourceNamespace.js   |       25 |      100 |        0 |       25 |     4,5,6,8,13,14 |
  Ten99PolicyResource.js |    70.67 |       43 |    77.42 |    70.67 |... 23,524,531,553 |
  makeRequest.js         |    86.05 |    73.08 |    85.71 |     87.8 |    21,37,46,71,72 |
  resources.js           |      100 |      100 |      100 |      100 |                   |
  ten99policy.js         |    83.58 |    69.23 |    85.71 |    83.58 |... 26,130,148,160 |
  utils.js               |    71.31 |    60.81 |    81.58 |    71.43 |... 38,347,348,353 |
 lib/resources           |      100 |      100 |      100 |      100 |                   |
  Contractors.js         |      100 |      100 |      100 |      100 |                   |
  Entities.js            |      100 |      100 |      100 |      100 |                   |
  Jobs.js                |      100 |      100 |      100 |      100 |                   |
  Policies.js            |      100 |      100 |      100 |      100 |                   |
  Quotes.js              |      100 |      100 |      100 |      100 |                   |
 testUtils               |     87.5 |    73.08 |    93.33 |     87.5 |                   |
  index.js               |     87.5 |    73.08 |    93.33 |     87.5 |... ,59,68,119,133 |
-------------------------|----------|----------|----------|----------|-------------------|